### PR TITLE
Fix FeatureX to be runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ Python library for extracting feature models from natural language specification
 
 ## Dependencies ##
 
-* itertools
-* matplotlib.pyplot
+* matplotlib
 * networkx
-* nltk
+* nltk (<3.5 for Python2)
 * Pattern
-* PdfMiner
+* PdfMiner (<20191010 for Python2)
+* pydot
 * scikit-learn
 
 **External tools used**

--- a/src/CaseStudy-Evaluations.py
+++ b/src/CaseStudy-Evaluations.py
@@ -3,8 +3,8 @@ import FeatureX
 import time
 
 from FeatureX import *
-from RelMiner import RelashionshipMiner
-from MLRel import MachineLearnRelations
+from RelationshipMiner import RelationshipMiner
+from RelationshipSegregator import RelationshipSegregator
 
 start_time = time.time()
 
@@ -27,7 +27,7 @@ start_time = time.time()
 fx = featurex('CryptoCurrency1.pdf','2-14') ## input file 1
 fx.pre_process()
 fx.extract_candidates()
-RelashionshipMiner()
+RelationshipMiner()
 RelationshipSegregator()
 
 ## Move all results
@@ -36,7 +36,7 @@ fx.clean_workspace()
 fx = featurex('CryptoCurrency2.pdf','3-35') ## input file 2
 fx.pre_process()
 fx.extract_candidates()
-RelashionshipMiner()
+RelationshipMiner()
 RelationshipSegregator()
 
 ## Move all results
@@ -45,7 +45,7 @@ fx.clean_workspace()
 fx = featurex('CryptoCurrency3.pdf','1-14') ## input file 3
 fx.pre_process()
 fx.extract_candidates()
-RelashionshipMiner()
+RelationshipMiner()
 RelationshipSegregator()
 
 # Move all results

--- a/src/FeatureX.py
+++ b/src/FeatureX.py
@@ -159,12 +159,12 @@ class featurex:
         src_dir = os.path.join(os.getcwd())
         dest_dir = os.path.join(os.getcwd(), datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S'))
         os.makedirs(dest_dir)
-        for txt_file in glob.glob(src_dir+"\\*.txt"):
+        for txt_file in glob.glob(os.path.join(src_dir, "*.txt")):
             if "NonsenseWords" not in txt_file:
                 shutil.move(txt_file, dest_dir)
-        for dot_file in glob.glob(src_dir+"\\*.dot"):
+        for dot_file in glob.glob(os.path.join(src_dir, "*.dot")):
             shutil.move(dot_file, dest_dir)
-        for png_file in glob.glob(src_dir+"\\*.png"):
+        for png_file in glob.glob(os.path.join(src_dir, "*.png")):
             shutil.move(png_file, dest_dir)
 
     def GetLastNoun(self):

--- a/src/RelationshipMiner.py
+++ b/src/RelationshipMiner.py
@@ -8,7 +8,7 @@ from nltk.tokenize import word_tokenize
 from nltk.tokenize import sent_tokenize
 from nltk import pos_tag
 
-class RelashionshipMiner:
+class RelationshipMiner:
     def __init__(self):
 
         features = []


### PR DESCRIPTION
I tried to run FeatureX with Python 2.7 on Ubuntu 20.04 and came across some troubles, so I'd like to fix them.
This PR addresses the following problem.

* The dependency list in README.md is incomplete.

  * itertools is included in Python core since v2.3, so it doesn't have to be in this list.

  * Recent NLTK and PDFMiner are not compatible with Python 2, but pip is going to install those incompatible versions without explicit version specification.

  * pydot is also required.

* The python modules "RelMiner" and "MLRel" referred to in CaseStudy-Evaluations.py don't exist actually.

* `featurex.clean_workspace()` assumes Windows-style folder path, so running it on other platforms (e.g., Linux) doesn't generate any output in the time-stamped directory.

I made sure that this fix worked as follows:

```
$ pip2 install matplotlib networkx 'nltk<3.5' Pattern 'PdfMiner<20191010' pydot scikit-learn 

...

Successfully installed Pattern-3.6 PdfMiner-20140328 backports.csv-1.0.7 backports.functools-lru-cache-1.6.4 beautifulsoup4-4.9.3 certifi-2021.5.30 chardet-4.0.0 cheroot-8.5.2 cherrypy-17.4.2 contextlib2-0.6.0.post1 cycler-0.10.0 decorator-4.4.2 feedparser-5.2.1 future-0.18.2 idna-2.10 jaraco.functools-2.0 kiwisolver-1.1.0 lxml-4.6.3 matplotlib-2.2.5 more-itertools-5.0.0 mysqlclient-1.4.6 networkx-2.2 nltk-3.4.5 numpy-1.16.6 portend-2.6 pydot-1.4.2 pyparsing-2.4.7 python-dateutil-2.8.1 python-docx-0.8.11 pytz-2021.1 requests-2.25.1 scikit-learn-0.20.4 scipy-1.2.3 selectors2-2.0.2 singledispatch-3.6.2 six-1.16.0 soupsieve-1.9.6 subprocess32-3.5.4 tempora-1.14.1 urllib3-1.26.6 zc.lockfile-2.0
$ cd examples
$ touch NonsenseWords.txt
$ python2 ../src/CaseStudy-Evaluations.py 
DONE R2
DONE R1
DONE R3
DONE R4
DONE
DONE R2
DONE R1
DONE R3
DONE R4
DONE
Traceback (most recent call last):
  File "/home/sekikn/repos/FeatureX/src/FeatureX.py", line 139, in pre_process
    docmain = reduce(lambda x, y: x+' '+y, [i[0] for i in mainfeature])
TypeError: reduce() of empty sequence with no initial value
DONE R2
Traceback (most recent call last):
  File "../src/CaseStudy-Evaluations.py", line 49, in <module>
    RelationshipSegregator()
  File "/home/sekikn/repos/FeatureX/src/RelationshipSegregator.py", line 140, in __init__
    dependencygraph()
  File "/home/sekikn/repos/FeatureX/src/DependencyGraph.py", line 59, in __init__
    if r and r[0] != '' and rootFeature in r[0]:
UnboundLocalError: local variable 'rootFeature' referenced before assignment
$ ls -l 2021-07-02_21-51-31
total 2356
-rw-rw-r-- 1 sekikn sekikn   53051 Jul  2 21:51 CandidateTerms.txt
-rw-rw-r-- 1 sekikn sekikn  116723 Jul  2 21:51 corpustext.txt
-rw-rw-r-- 1 sekikn sekikn  289082 Jul  2 21:51 DependencyGraph.png
-rw-rw-r-- 1 sekikn sekikn   10984 Jul  2 21:51 grid.dot
-rw-rw-r-- 1 sekikn sekikn  115154 Jul  2 21:51 processedtext.txt
-rw-rw-r-- 1 sekikn sekikn    6574 Jul  2 21:51 R1.txt
-rw-rw-r-- 1 sekikn sekikn    5809 Jul  2 21:51 R2.txt
-rw-rw-r-- 1 sekikn sekikn    5958 Jul  2 21:51 R3.txt
-rw-rw-r-- 1 sekikn sekikn    2090 Jul  2 21:51 R4.txt
-rw-rw-r-- 1 sekikn sekikn    3764 Jul  2 21:51 Refined-R1-FeatureRelations.txt
-rw-rw-r-- 1 sekikn sekikn    2812 Jul  2 21:51 Refined-R2-FeatureRelations.txt
-rw-rw-r-- 1 sekikn sekikn    2945 Jul  2 21:51 Refined-R3-FeatureRelations.txt
-rw-rw-r-- 1 sekikn sekikn     925 Jul  2 21:51 Refined-R4-FeatureRelations.txt
-rw-rw-r-- 1 sekikn sekikn       8 Jul  2 21:51 RootFeature.txt
-rw-rw-r-- 1 sekikn sekikn 1765546 Jul  2 21:51 SubjectObject.txt
$ cat 2021-07-02_21-51-31/RootFeature.txt 
Zerocoin
```

The last error was for processing CryptoCurrency3.pdf, but CryptoCurrency1.pdf and CryptoCurrency2.pdf were successfull processed. I'll file this error as another issue.